### PR TITLE
Use existing search permission for onesearch.

### DIFF
--- a/apachesolr_onesearch.module
+++ b/apachesolr_onesearch.module
@@ -100,7 +100,7 @@ function apachesolr_onesearch_menu(){
     'description' => 'Configure the One Search search block',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('apachesolr_onesearch_settings'),
-    'access arguments' => array('administer onesearch settings'),
+    'access arguments' => array('administer search'),
   );
 
   return $items;

--- a/test.php
+++ b/test.php
@@ -1,0 +1,15 @@
+<?php
+
+
+
+
+
+# Add profile picture uri when indexing users
+$my_user = entity_metadata_wrapper('user', 328);
+
+
+foreach ( $my_user->value()->roles as $key => $value) {
+
+  drush_print( $value);
+
+ }


### PR DESCRIPTION
Applies "administer search" permission to one search settings. 

Motivation and Context
----------------------
Previous permissions were broken and menu was only available to admin user.  Also, onesearch doesn't need it's own perms. Nobody will be administering onesearch but not search in general. 

How Has This Been Tested?
-------------------------
Works in vagrant for admin user and normal users. 
